### PR TITLE
Fix 32-bit builds (fixes #10).

### DIFF
--- a/include/win32/dbghelp.h
+++ b/include/win32/dbghelp.h
@@ -274,6 +274,18 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
 } CONTEXT, *PCONTEXT;
 typedef PCONTEXT LPCONTEXT;
 #elif _WIN32
+typedef struct _FLOATING_SAVE_AREA
+{
+    ULONG ControlWord;
+    ULONG StatusWord;
+    ULONG TagWord;
+    ULONG ErrorOffset;
+    ULONG ErrorSelector;
+    ULONG DataOffset;
+    ULONG DataSelector;
+    UCHAR RegisterArea[80];
+    ULONG Cr0NpxState;
+} FLOATING_SAVE_AREA, *PFLOATING_SAVE_AREA;
 #define MAXIMUM_SUPPORTED_EXTENSION     512
 typedef struct _CONTEXT {
     DWORD ContextFlags;

--- a/include/win32/windows.h
+++ b/include/win32/windows.h
@@ -928,6 +928,18 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
 } CONTEXT, *PCONTEXT;
 typedef PCONTEXT LPCONTEXT;
 #elif _WIN32
+typedef struct _FLOATING_SAVE_AREA
+{
+    ULONG ControlWord;
+    ULONG StatusWord;
+    ULONG TagWord;
+    ULONG ErrorOffset;
+    ULONG ErrorSelector;
+    ULONG DataOffset;
+    ULONG DataSelector;
+    UCHAR RegisterArea[80];
+    ULONG Cr0NpxState;
+} FLOATING_SAVE_AREA, *PFLOATING_SAVE_AREA;
 #define MAXIMUM_SUPPORTED_EXTENSION     512
 typedef struct _CONTEXT {
     DWORD ContextFlags;


### PR DESCRIPTION
This is just a matter of defining struct _FLOATING_SAVE_AREA which is
required by struct _CONTEXT.